### PR TITLE
Add flags to disable package installation using the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Tested on Ubuntu 14.04, 16.04 and CentOS 7, should also run under Debian and Red
 * `check_mk_agent_monitoring_host_wato_username:`
 * `check_mk_agent_monitoring_host_wat_secret:`
 * `check_mk_agent_setup_firewall: True` Add firewall rule (ufw/firewalld) when using systemd-socket
+* `check_mk_agent_manual_install: False` Leave agent package installation to the user
 
 ## Included check_mk extra plugins
 * apache\_status

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ check_mk_agent_add_to_wato: False
 check_mk_agent_monitoring_host_folder: ""
 check_mk_agent_monitoring_host_discovery_mode: "new"
 check_mk_agent_setup_firewall: True
+check_mk_agent_manual_install: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   package:
     name: check-mk-agent
     state: latest
+  when: check_mk_agent_manual_install == False
 
 - name: Install plugin requirements
   package:


### PR DESCRIPTION
I have problems using the default 'package' module in my environment, and want to do the agent installation on the side. These flags allow me to disable package installation in the module.