### PR TITLE
Only edit host if attributes differ

### DIFF
--- a/library/check_mk.py
+++ b/library/check_mk.py
@@ -227,8 +227,9 @@ def main():
 
     # Adjust attributes
     if a_module.params["hostname"] and host_exists and  a_module.params["attributes"]:
-        result["changed"] = True
-        result["edit_host"] = cmk.edit_host(a_module.params["hostname"], a_module.params["attributes"])
+        if not a_module.params["attributes"].viewitems() <= cmk.get_host_attributes(a_module.params["hostname"])["attributes"].viewitems():
+            result["changed"] = True
+            result["edit_host"] = cmk.edit_host(a_module.params["hostname"], a_module.params["attributes"])
 
     # discover services
     if a_module.params["discover_services"]:

--- a/library/check_mk.py
+++ b/library/check_mk.py
@@ -227,7 +227,7 @@ def main():
 
     # Adjust attributes
     if a_module.params["hostname"] and host_exists and  a_module.params["attributes"]:
-        if not a_module.params["attributes"].viewitems() <= cmk.get_host_attributes(a_module.params["hostname"])["attributes"].viewitems():
+        if not a_module.params["attributes"].items() <= cmk.get_host_attributes(a_module.params["hostname"])["attributes"].items():
             result["changed"] = True
             result["edit_host"] = cmk.edit_host(a_module.params["hostname"], a_module.params["attributes"])
 


### PR DESCRIPTION
So far the host was always updated in WATO if attributes was set.
Now it will only be updated if attributes is not a subset of the attributes dict pulled from WATO.