### PR TITLE
add xinetd configuration, Fix issue : xinetd configure #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Tested on Ubuntu 16.04, 18.04 and CentOS 7, should also run under Debian and Red
 * `check_mk_agent_monitoring_host_wato_secret:`
 * `check_mk_agent_setup_firewall: true` Add firewall rule (ufw/firewalld) when using systemd-socket or xinetd
 * `check_mk_agent_manual_install: false` Leave agent package installation to the user
-* `check_mk_agent_xinetd_only_from: '127.0.0.1'` IP address permit to run check_mk over xinetd
+* `check_mk_agent_xinetd_only_from: ""` IP address permit to run check_mk over xinetd, if not define permit from everywhere
 * `check_mk_agent_xinetd_port: 6556` xinetd port used for check_mk
 
 ## Included check_mk extra plugins

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Tested on Ubuntu 16.04, 18.04 and CentOS 7, should also run under Debian and Red
 * `check_mk_agent_monitoring_host_wato_secret:`
 * `check_mk_agent_setup_firewall: true` Add firewall rule (ufw/firewalld) when using systemd-socket or xinetd
 * `check_mk_agent_manual_install: false` Leave agent package installation to the user
+* `check_mk_agent_xinetd_only_from: '127.0.0.1'` IP address permit to run check_mk over xinetd
+* `check_mk_agent_xinetd_port: 6556` xinetd port used for check_mk
 
 ## Included check_mk extra plugins
 Could be found under `files/plugins/`. As it is hard to keep these plugins

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,4 @@ check_mk_agent_monitoring_host_folder: ""
 check_mk_agent_monitoring_host_discovery_mode: "new"
 check_mk_agent_setup_firewall: true
 check_mk_agent_manual_install: false
+check_mk_agent_xinetd_only_from: '127.0.0.1'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,6 +5,11 @@
     name: firewalld
     state: restarted
 
+- name: Restart xinetd
+  service:
+    name: xinetd
+    state: restarted
+
 - name: Check_mk activate changes via WATO API
   check_mk:
     server_url: "{{ check_mk_agent_monitoring_host_url }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,7 +91,7 @@
     - name: Add check_mk xinetd service
       template:
         src: check_mk.j2
-        dest: /etc/xinetd.d/check_mk
+        dest: /etc/xinetd.d/check-mk-agent
       notify:
         - Restart xinetd
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,6 +88,13 @@
         state: started
         enabled: true
 
+    - name: Add check_mk xinetd service
+      template:
+        src: check_mk.j2
+        dest: /etc/xinetd.d/check_mk
+      notify:
+        - Restart xinetd
+
     - name: Allow check_mk.socket (ufw)
       ufw:
         rule: allow

--- a/templates/check_mk.j2
+++ b/templates/check_mk.j2
@@ -1,0 +1,49 @@
+# +------------------------------------------------------------------+
+# |             ____ _               _        __  __ _  __           |
+# |            / ___| |__   ___  ___| | __   |  \/  | |/ /           |
+# |           | |   | '_ \ / _ \/ __| |/ /   | |\/| | ' /            |
+# |           | |___| | | |  __/ (__|   <    | |  | | . \            |
+# |            \____|_| |_|\___|\___|_|\_\___|_|  |_|_|\_\           |
+# |                                                                  |
+# | Copyright Mathias Kettner 2010             mk@mathias-kettner.de |
+# +------------------------------------------------------------------+
+#
+# This file is part of Check_MK.
+# The official homepage is at http://mathias-kettner.de/check_mk.
+#
+# check_mk is free software;  you can redistribute it and/or modify it
+# under the  terms of the  GNU General Public License  as published by
+# the Free Software Foundation in version 2.  check_mk is  distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;  with-
+# out even the implied warranty of  MERCHANTABILITY  or  FITNESS FOR A
+# PARTICULAR PURPOSE. See the  GNU General Public License for more de-
+# ails.  You should have  received  a copy of the  GNU  General Public
+# License along with GNU Make; see the file  COPYING.  If  not,  write
+# to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
+# Boston, MA 02110-1301 USA.
+
+service check_mk
+{
+	type           = UNLISTED
+	port           = {{ check_mk_agent_xinetd_port | default ('6556') }}
+	socket_type    = stream
+	protocol       = tcp
+	wait           = no
+	user           = root
+	server         = /usr/bin/check_mk_agent
+
+	# If you use fully redundant monitoring and poll the client
+	# from more then one monitoring servers in parallel you might
+	# want to use the agent cache wrapper:
+	#server         = /usr/bin/check_mk_caching_agent
+
+	# configure the IP address(es) of your Nagios server here:
+	only_from      = {{ check_mk_agent_xinetd_only_from }}
+
+	# Don't be too verbose. Don't log every check. This might be
+	# commented out for debugging. If this option is commented out
+	# the default options will be used for this service.
+	log_on_success =
+
+	disable        = no
+}

--- a/templates/check_mk.j2
+++ b/templates/check_mk.j2
@@ -5,7 +5,7 @@
 # |           | |___| | | |  __/ (__|   <    | |  | | . \            |
 # |            \____|_| |_|\___|\___|_|\_\___|_|  |_|_|\_\           |
 # |                                                                  |
-# | Copyright Mathias Kettner 2010             mk@mathias-kettner.de |
+# | Copyright Mathias Kettner 2014             mk@mathias-kettner.de |
 # +------------------------------------------------------------------+
 #
 # This file is part of Check_MK.
@@ -17,7 +17,7 @@
 # in the hope that it will be useful, but WITHOUT ANY WARRANTY;  with-
 # out even the implied warranty of  MERCHANTABILITY  or  FITNESS FOR A
 # PARTICULAR PURPOSE. See the  GNU General Public License for more de-
-# ails.  You should have  received  a copy of the  GNU  General Public
+# tails. You should have  received  a copy of the  GNU  General Public
 # License along with GNU Make; see the file  COPYING.  If  not,  write
 # to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 # Boston, MA 02110-1301 USA.
@@ -32,14 +32,19 @@ service check_mk
 	user           = root
 	server         = /usr/bin/check_mk_agent
 
+        # listen on IPv4 AND IPv6 when available on this host
+        #flags          = IPv6
 	# If you use fully redundant monitoring and poll the client
 	# from more then one monitoring servers in parallel you might
 	# want to use the agent cache wrapper:
 	#server         = /usr/bin/check_mk_caching_agent
 
 	# configure the IP address(es) of your Nagios server here:
+{% if check_mk_agent_xinetd_only_from is defined %}
 	only_from      = {{ check_mk_agent_xinetd_only_from }}
-
+{% else %}
+	#only_from      = 127.0.0.1 10.0.20.1 10.0.20.2
+{% endif %}
 	# Don't be too verbose. Don't log every check. This might be
 	# commented out for debugging. If this option is commented out
 	# the default options will be used for this service.


### PR DESCRIPTION
- add two new variables :
  - check_mk_agent_xinetd_port
  - check_mk_agent_xinetd_only_from
- add /etc/xinetd.d/check_mk configuration
- add handers to restart xinetd in case of configuration change