### PR TITLE
Option for disabling verifying certs for self-signed certs when calling WATO API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Tested on Ubuntu 16.04, 18.04 and CentOS 7, should also run under Debian and Red
 * `check_mk_agent_monitoring_host_wato_secret:`
 * `check_mk_agent_setup_firewall: true` Add firewall rule (ufw/firewalld) when using systemd-socket or xinetd
 * `check_mk_agent_manual_install: false` Leave agent package installation to the user
+* `check_mk_agent_verify_certs: true` Verify SSL certs when callimg WATO API (default is true)
 
 ## Included check_mk extra plugins
 Could be found under `files/plugins/`. As it is hard to keep these plugins

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Tested on Ubuntu 16.04, 18.04 and CentOS 7, should also run under Debian and Red
 * `check_mk_agent_setup_firewall: true` Add firewall rule (ufw/firewalld) when using systemd-socket or xinetd
 * `check_mk_agent_manual_install: false` Leave agent package installation to the user
 * `check_mk_agent_verify_certs: true` Verify SSL certs when callimg WATO API (default is true)
+* `check_mk_package_state: present` Package state present/latest, determines whether to upgrade existing packages. 
 
 ## Included check_mk extra plugins
 Could be found under `files/plugins/`. As it is hard to keep these plugins

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,4 @@ check_mk_agent_monitoring_host_discovery_mode: "new"
 check_mk_agent_setup_firewall: true
 check_mk_agent_manual_install: false
 check_mk_agent_validate_certs: true
+chck_mk_agent_package_state: present

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,4 @@ check_mk_agent_monitoring_host_folder: ""
 check_mk_agent_monitoring_host_discovery_mode: "new"
 check_mk_agent_setup_firewall: true
 check_mk_agent_manual_install: false
+check_mk_agent_validate_certs: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,5 +10,6 @@
     server_url: "{{ check_mk_agent_monitoring_host_url }}"
     username: "{{ check_mk_agent_monitoring_host_wato_username }}"
     secret: "{{ check_mk_agent_monitoring_host_wato_secret }}"
+    validate_certs: "{{ check_mk_agent_validate_certs }}"
     activate_changes: true
   delegate_to: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Install check_mk_agent
   package:
     name: check-mk-agent
-    state: present
+    state: "{{ chck_mk_agent_package_state }}"
   when: not check_mk_agent_manual_install
 
 - name: Install plugin requirements

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -163,6 +163,7 @@
     server_url: "{{ check_mk_agent_monitoring_host_url }}"
     username: "{{ check_mk_agent_monitoring_host_wato_username }}"
     secret: "{{ check_mk_agent_monitoring_host_wato_secret }}"
+    validate_certs: "{{ check_mk_agent_validate_certs }}"
     hostname: "{{ inventory_hostname }}"
     folder: "{{ check_mk_agent_monitoring_host_folder }}"
     state: present
@@ -177,6 +178,7 @@
     server_url: "{{ check_mk_agent_monitoring_host_url }}"
     username: "{{ check_mk_agent_monitoring_host_wato_username }}"
     secret: "{{ check_mk_agent_monitoring_host_wato_secret }}"
+    validate_certs: "{{ check_mk_agent_validate_certs }}"
     hostname: "{{ inventory_hostname }}"
     discover_services: "{{ check_mk_agent_monitoring_host_discovery_mode }}"
   when: check_mk_agent_add_host_wato.changed


### PR DESCRIPTION
1) Support for disabling SSL cert verification when calling WATO API for self signed certs.
2) Support upgrading CMK packages that are already installed (resolves #26 )