### PR TITLE
Host is not added to Check_MK Instance

### DIFF
--- a/library/check_mk.py
+++ b/library/check_mk.py
@@ -188,7 +188,7 @@ class CheckMKAPI(object):
 
     def host_exists(self, hostname):
         return self._api_request("&action=get_host&effective_attributes=1", {"hostname": hostname},
-                                 False) != "Check_MK exception: No such host"
+                                 False) != "Checkmk exception: No such host"
 
 
 def main():


### PR DESCRIPTION
Hi there!
I use this role a lot in our ansible production environment. Thank you for developing and keeping it updated!
Recently I noticed, that new host are not added since the upgrade to Check_MK Raw 2.0.
In 2.0 they changed the error messages from Check_MK to Checkmk.
My solution in this PR may be too easy.
It would be better to compare the end of the String "No such host".
Maybe you can implement this and close the PR.